### PR TITLE
Improve drawing view deletion fallback

### DIFF
--- a/WaterjetNesting1.bas
+++ b/WaterjetNesting1.bas
@@ -1233,14 +1233,39 @@ Private Sub DeleteAllViewsExcept(dd As SldWorks.DrawingDoc, keepName As String)
         currentName = v.Name
 
         If StrComp(currentName, keepName, vbTextCompare) <> 0 Then
-            If Not CallByName(dd, "DeleteView", VbMethod, currentName) Then
-                dd.ActivateView currentName
-                Dim md As SldWorks.ModelDoc2: Set md = dd
-                If Not md.SelectByID2(currentName, "DRAWINGVIEW", 0, 0, 0, False, 0, Nothing, 0) Then
-                    LogMessage "[DXF] Failed to select view " & currentName & " for deletion"
-                ElseIf md.DeleteSelection2(0) = 0 Then
-                    LogMessage "[DXF] DeleteSelection2 failed for view " & currentName
+            Dim deleted As Boolean: deleted = False
+
+            ' First try the direct DeleteView API
+            If CallByName(dd, "DeleteView", VbMethod, currentName) Then
+                deleted = True
+            Else
+                ' Fallback #1: use the view object itself to drive the deletion
+                If Not deleted Then
+                    If CallByName(v, "Select2", VbMethod, False, Nothing) Then
+                        If CallByName(dd, "EditDelete", VbMethod) Then
+                            deleted = True
+                        Else
+                            CallByName(dd, "ClearSelection2", VbMethod, True)
+                        End If
+                    End If
                 End If
+
+                ' Fallback #2: legacy SelectByID2 behaviour
+                If Not deleted Then
+                    dd.ActivateView currentName
+                    Dim md As SldWorks.ModelDoc2: Set md = dd
+                    If Not md.SelectByID2(currentName, "DRAWINGVIEW", 0, 0, 0, False, 0, Nothing, 0) Then
+                        LogMessage "[DXF] Failed to select view " & currentName & " for deletion"
+                    ElseIf CallByName(md, "DeleteSelection2", VbMethod, 0) = 0 Then
+                        LogMessage "[DXF] DeleteSelection2 failed for view " & currentName
+                    Else
+                        deleted = True
+                    End If
+                End If
+            End If
+
+            If Not deleted Then
+                LogMessage "[DXF] Unable to delete view " & currentName & " after all attempts"
             End If
         End If
 


### PR DESCRIPTION
## Summary
- add multiple deletion fallbacks when removing extra drawing views
- log a single failure message after all removal strategies are attempted

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d32942c4a88320be67a47307f9fd91